### PR TITLE
build: Update discordeno & typescript, use `.js` & `.d.ts` for publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,67 +7,68 @@
     "": {
       "name": "dd-cache-proxy",
       "version": "2.0.2",
-      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@discordeno/bot": "^19.0.0-next.730ad9a",
-        "typescript": "^4.8.4"
+        "@discordeno/bot": "19.0.0-next.687c29d"
+      },
+      "devDependencies": {
+        "typescript": "^5.4.5"
       }
     },
     "node_modules/@discordeno/bot": {
-      "version": "19.0.0-next.730ad9a",
-      "resolved": "https://registry.npmjs.org/@discordeno/bot/-/bot-19.0.0-next.730ad9a.tgz",
-      "integrity": "sha512-axE0KYgfNHiatojKzUKOl8j7NGqfa67mB8kxouUamDOBkzWy4krbqbszN2adogOBqzcX0IvCllDFpF4glzSr+Q==",
+      "version": "19.0.0-next.687c29d",
+      "resolved": "https://registry.npmjs.org/@discordeno/bot/-/bot-19.0.0-next.687c29d.tgz",
+      "integrity": "sha512-SoEe9fnj9TsvwGLvsmUXhJfGXLUnXmPmBVAVB5BpM6Q78gOaXsComLBJclHiQRtRgisjzWe3oVvpO1Bmojgerg==",
       "dependencies": {
-        "@discordeno/gateway": "19.0.0-next.730ad9a",
-        "@discordeno/rest": "19.0.0-next.730ad9a",
-        "@discordeno/types": "19.0.0-next.730ad9a",
-        "@discordeno/utils": "19.0.0-next.730ad9a"
+        "@discordeno/gateway": "19.0.0-next.687c29d",
+        "@discordeno/rest": "19.0.0-next.687c29d",
+        "@discordeno/types": "19.0.0-next.687c29d",
+        "@discordeno/utils": "19.0.0-next.687c29d"
       }
     },
     "node_modules/@discordeno/gateway": {
-      "version": "19.0.0-next.730ad9a",
-      "resolved": "https://registry.npmjs.org/@discordeno/gateway/-/gateway-19.0.0-next.730ad9a.tgz",
-      "integrity": "sha512-t+4/jyZhN4m1z4exMWHVtJO5hkX5/RP8QLhJqXy9voEG5fDGVjZek5QPXcN3RQWif3SqC3ztg0OdVY6fd2mwvA==",
+      "version": "19.0.0-next.687c29d",
+      "resolved": "https://registry.npmjs.org/@discordeno/gateway/-/gateway-19.0.0-next.687c29d.tgz",
+      "integrity": "sha512-ysp3Ht4FmzZ4PsmUFf3IZSxTG0ZnoFL+/YItbWq7OuHxeiZA14AJn0Eg2R+BBLemxGXoYOkHEuHOsIG0ynxIkQ==",
       "dependencies": {
-        "@discordeno/types": "19.0.0-next.730ad9a",
-        "@discordeno/utils": "19.0.0-next.730ad9a",
-        "ws": "^8.13.0"
+        "@discordeno/types": "19.0.0-next.687c29d",
+        "@discordeno/utils": "19.0.0-next.687c29d",
+        "ws": "^8.16.0"
       }
     },
     "node_modules/@discordeno/rest": {
-      "version": "19.0.0-next.730ad9a",
-      "resolved": "https://registry.npmjs.org/@discordeno/rest/-/rest-19.0.0-next.730ad9a.tgz",
-      "integrity": "sha512-ZpxFmXbV9hmCaYi0Eo0C9/+5U2zmm0arUP6GRpD9dDi9Mf1KmU18+keEERqiNg5EG9P4PJcViuLLu32GpuRb2w==",
+      "version": "19.0.0-next.687c29d",
+      "resolved": "https://registry.npmjs.org/@discordeno/rest/-/rest-19.0.0-next.687c29d.tgz",
+      "integrity": "sha512-i480Wvv/AJCMJVdCDfvzZI53/h1xqJ1J+UVeU+j6UqY24wNCh/c2korW/jsHg978GCBIlsHyGJWE0JQRSwIDeA==",
       "dependencies": {
-        "@discordeno/types": "19.0.0-next.730ad9a",
-        "@discordeno/utils": "19.0.0-next.730ad9a",
-        "dotenv": "^16.0.3"
+        "@discordeno/types": "19.0.0-next.687c29d",
+        "@discordeno/utils": "19.0.0-next.687c29d",
+        "dotenv": "^16.4.5"
       }
     },
     "node_modules/@discordeno/types": {
-      "version": "19.0.0-next.730ad9a",
-      "resolved": "https://registry.npmjs.org/@discordeno/types/-/types-19.0.0-next.730ad9a.tgz",
-      "integrity": "sha512-tLiPJCcL1tasb0Al5hW1pHbLv9x5sdsmiavhXtlv+NQoJH6/FrFZXbXdYu09lcC3cRxfE72PFhtFpcYFCtdYCg=="
+      "version": "19.0.0-next.687c29d",
+      "resolved": "https://registry.npmjs.org/@discordeno/types/-/types-19.0.0-next.687c29d.tgz",
+      "integrity": "sha512-O3dly+xilSNsdhxCOUYDIfaH6bTQF46Ro0eGmD+A7R3dvREy92NJcCdrW3xLBkZZC3TnUI+cXRxDa6SlivJdeQ=="
     },
     "node_modules/@discordeno/utils": {
-      "version": "19.0.0-next.730ad9a",
-      "resolved": "https://registry.npmjs.org/@discordeno/utils/-/utils-19.0.0-next.730ad9a.tgz",
-      "integrity": "sha512-ajavvMjiGWx80NCt8YrXTWfLPtitoOEB3BZLuSc1KNp25rGC4T2m4VZ79/xznAK7dXUjBubB54qGTls2iLBk+g==",
+      "version": "19.0.0-next.687c29d",
+      "resolved": "https://registry.npmjs.org/@discordeno/utils/-/utils-19.0.0-next.687c29d.tgz",
+      "integrity": "sha512-NQy9EACypzEWZ6OB6T8IzAlZD08HKZpO3IDFFAL1wZ9qGlGvsG/SgUF9hv57IWTh68Z1ozG9eEM8KQpwRAHO/w==",
       "dependencies": {
-        "@discordeno/types": "19.0.0-next.730ad9a",
+        "@discordeno/types": "19.0.0-next.687c29d",
         "tweetnacl": "^1.0.3"
       }
     },
     "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "engines": {
         "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/tweetnacl": {
@@ -76,21 +77,22 @@
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "version": "2.0.2",
   "description": "A simple, easy-to-use, highly customizable cache proxy for discordeno which supports in-memory and outside memory caching with custom properties you wish to cache.",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "prepare": "tsc",
-    "preinstall": "tsc",
     "tsc": "tsc --noEmit --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -14,15 +14,21 @@
     "type": "git",
     "url": "git+https://github.com/AwesomeStickz/dd-cache-proxy.git"
   },
-  "keywords": [],
+  "keywords": [ ],
   "author": "",
   "license": "ISC",
+  "files": [
+    "dist",
+    "package.json"
+  ],
   "bugs": {
     "url": "https://github.com/AwesomeStickz/dd-cache-proxy/issues"
   },
   "homepage": "https://github.com/AwesomeStickz/dd-cache-proxy#readme",
   "dependencies": {
-    "@discordeno/bot": "^19.0.0-next.730ad9a",
-    "typescript": "^4.8.4"
+    "@discordeno/bot": "19.0.0-next.687c29d"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,10 @@
     "compilerOptions": {
         "target": "ES2020",
         "module": "ESNext",
-        "lib": ["ES2020", "DOM"],
+        "lib": [ "ES2020", "DOM" ],
         "allowJs": true,
         "outDir": "./dist",
+        "declaration": true,
         "importHelpers": true,
 
         "strict": true,


### PR DESCRIPTION
This PR aims to fix some NPM resolution errors (see [these discord messages](https://discord.com/channels/785384884197392384/785384884197392387/1235646611720503296) on the [discordeno discord server](https://discord.gg/ddeno))

The changes include:
- Saving exactly the version of discordeno to use (I have updated it to the latest, if that has some issues I can revert the change)
- Updating typescript to v5 (If there are issues I can revert that as well)
- Modified the `tsconfig.json` to emit declaration (`.d.ts` files) along the source (`.js` files)
- Modified the scripts in the `package.json` to `tsc` on `prepare` instead of `prepare` & `preinstall`